### PR TITLE
Drop support for root version < 6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,12 +34,8 @@ find_package( DD4hep REQUIRED COMPONENTS DDRec )
 set(CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH}  ${DD4hep_ROOT}/cmake ) 
 include( DD4hep )
 
-find_package( ROOT REQUIRED )
-if ( ${ROOT_VERSION_MAJOR} GREATER 5 )
-  set( ROOT_COMPONENT_LIBRARIES Geom )
-else()
-  set( ROOT_COMPONENT_LIBRARIES Geom Reflex)
-endif()
+find_package( ROOT 6 REQUIRED )
+set( ROOT_COMPONENT_LIBRARIES Geom )
 
 
 if(DD4HEP_USE_XERCESC)


### PR DESCRIPTION
Re-running cmake was failing because ROOT_VERSION_MAJOR was un-defined, this will fix that as well.

BEGINRELEASENOTES
- Dropped support for root version < 6

ENDRELEASENOTES