### PR TITLE
Clean Cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,8 +34,7 @@ find_package( DD4hep REQUIRED COMPONENTS DDRec )
 set(CMAKE_MODULE_PATH  ${CMAKE_MODULE_PATH}  ${DD4hep_ROOT}/cmake ) 
 include( DD4hep )
 
-find_package( ROOT 6 REQUIRED )
-set( ROOT_COMPONENT_LIBRARIES Geom )
+find_package( ROOT 6 REQUIRED COMPONENTS Geom )
 
 
 if(DD4HEP_USE_XERCESC)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.3 FATAL_ERROR)
 
 #---------------------------
 set( PackageName DDKalTest )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -133,4 +133,4 @@ DISPLAY_STD_VARIABLES()
 
 
 # generate and install following configuration files
-GENERATE_PACKAGE_CONFIGURATION_FILES( DDKalTestConfig.cmake DDKalTestConfigVersion.cmake DDKalTestLibDeps.cmake )
+GENERATE_PACKAGE_CONFIGURATION_FILES( DDKalTestConfig.cmake DDKalTestConfigVersion.cmake )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,12 +43,6 @@ if(DD4HEP_USE_XERCESC)
 endif()
 
 include(DD4hep_XML_setup)
- 
-#fg: fixme: for now need to link against geant4 libraries:
-find_package(Geant4 REQUIRED gdml ui_all vis_all)
-INCLUDE(${Geant4_USE_FILE})   # this also takes care of geant 4 definitions and include dirs
-LINK_LIBRARIES( ${Geant4_LIBRARIES} )
-
 
 
 #-------------------------------------------------------------


### PR DESCRIPTION
I compiled everything, and I didn't find anything that still needs Geant4 to be linked here.

BEGINRELEASENOTES
- CMake Configuration cleanup: Remove linking against Geant4
- Require CMake 3.3 (same as DD4hep)

ENDRELEASENOTES