### PR TITLE
allow for unbounded DDCylinderMeasLayers (TPC)

### DIFF
--- a/include/DDKalTest/DDCylinderMeasLayer.h
+++ b/include/DDKalTest/DDCylinderMeasLayer.h
@@ -26,16 +26,16 @@ public:
   
   
   Bool_t IsOnSurface(const TVector3 &xx) const {
-    
+
     //fg: leave this code for now - we are restricted to cylinders around the z-axis
-    bool z = (xx.Z() >= GetZmin() && xx.Z() <= GetZmax());
+    bool z = ( _surf->type().isUnbounded() ?  true : (xx.Z() >= GetZmin() && xx.Z() <= GetZmax()) );
     bool r = std::fabs( (xx-this->GetXc()).Perp() - this->GetR() ) < 1.e-3; // for very short, very stiff tracks this can be poorly defined, so we relax this here a bit to 1 micron
-    
+
     //    streamlog_out(DEBUG0) << "DDCylinderMeasLayer IsOnSurface for " << this->TVMeasLayer::GetName() << " R =  " << this->GetR() 
     //    << "  GetZmin() = " << GetZmin() << " GetZmax() = " << GetZmax()
     //    << " dr = " << std::fabs( (xx-this->GetXc()).Perp() - this->GetR() ) << " r = " << r << " z = " << z 
     //    << std::endl;
-    
+
     return r && z;
   }
 
@@ -85,9 +85,12 @@ public:
                                        Int_t     mode,
                                        Double_t  eps = 1.e-8) const {
     
-    CellID = this->getCellIDs()[0]; // not multilayer
-    return this->CalcXingPointWith(hel,xx,phi,0,eps);
-    
+    int ret = this->CalcXingPointWith(hel,xx,phi,0,eps) ;
+
+    CellID = ( ( this->getCellIDs().size() > 1 && xx.Z() < 0. ) ?
+	       this->getCellIDs()[1] :  this->getCellIDs()[0]  ) ;    // multilayer cylinder ?
+
+    return ret ;
   }
 
   Double_t GetSortingPolicy() const { return fSortingPolicy; }

--- a/src/DDCylinderMeasLayer.cc
+++ b/src/DDCylinderMeasLayer.cc
@@ -52,6 +52,12 @@ DDCylinderMeasLayer::DDCylinderMeasLayer(DDSurfaces::ISurface* surf,
 
   int side = encoder[ UTIL::LCTrackerCellID::side() ] ;
 
+  // if we have an unbounded surface and the side is set to one, we also add the cellID for the other side (multilayer)
+  if( side == 1 && surf->type().isUnbounded() ){
+    encoder[ UTIL::LCTrackerCellID::side() ] = -1 ;
+    _cellIDs.push_back( encoder.lowWord() ) ;
+  }
+
   fSortingPolicy = dynamic_cast<DDSurfaces::ICylinder*>(surf)->radius()/dd4hep::mm + side * epsilon ;
 
   // assumptions made here: the cylinder runs parallel to z and v ...
@@ -392,19 +398,19 @@ Int_t DDCylinderMeasLayer::CalcXingPointWith(const TVTrack  &hel,
     s /= dd4hep::mm ; 
 
     xx.SetXYZ( xxV3[0]/dd4hep::mm , xxV3[1]/dd4hep::mm,  xxV3[2]/dd4hep::mm) ;   
-    
-    streamlog_out( DEBUG2 ) << " ++++  intersection found for surface : " << UTIL::LCTrackerCellID::valueString(_surf->id()) << std::endl 
-     			    << "       at s = " << s 
-     			    << "       xx   = ( " << xx.X() << ", " << xx.Y() << ", " << xx.Z() << ") " << std::endl 
-              		    << " track parameters: " <<  aidaTT::trackParameters( hp, rp ) 
-  			    << " mode: " << mode
-     			    <<  std::endl ;
+
+    streamlog_out( DEBUG3 ) << " ++++  intersection found for surface : " << UTIL::LCTrackerCellID::valueString(_surf->id()) << std::endl
+			    << "       at s = " << s
+			    << "       xx   = ( " << xx.X() << ", " << xx.Y() << ", " << xx.Z() << ") " << std::endl
+			    << " track parameters: " <<  aidaTT::trackParameters( hp, rp )
+			    << " mode: " << mode
+			    <<  std::endl ;
     
     phi = -s * omega ; 
     
   } else {
 
-    streamlog_out( DEBUG0 ) << " ++++ no intersection found for surface : " << UTIL::LCTrackerCellID::valueString(_surf->id()) << std::endl
+    streamlog_out( DEBUG3 ) << " ++++ no intersection found for surface : " << UTIL::LCTrackerCellID::valueString(_surf->id()) << std::endl
 			    << " track parameters: " <<  aidaTT::trackParameters( hp, rp ) 
   			    << " mode : " << mode
   			    << std::endl ;
@@ -467,5 +473,4 @@ Int_t DDCylinderMeasLayer::CalcXingPointWith(const TVTrack  &hel,
   //  return TCylinder::CalcXingPointWith( hel,xx,phi,mode,eps) ;
 
   return (IsOnSurface(xx) ? 1 : 0);
-
 }

--- a/src/DDVMeasLayer.cc
+++ b/src/DDVMeasLayer.cc
@@ -284,7 +284,7 @@ Double_t DDVMeasLayer::GetEnergyLoss( Bool_t    isoutgoing,
   }
 
 
-  streamlog_out(DEBUG7) << " eloss LCTracker: " << edep << ", " << UTIL::LCTrackerCellID::valueString( _surf->id() )
+  streamlog_out(DEBUG2) << " eloss LCTracker: " << edep << ", " << UTIL::LCTrackerCellID::valueString( _surf->id() )
   			<< " surface: " << *_surf 
   			<< std::endl ;
   


### PR DESCRIPTION
BEGINRELEASENOTES
- allow for unbounded DDCylinderMeasLayers 
   - to be used for the ILD TPC
   - if VolCylinder is marked as unbounded, we use a 'multilayer', ie.
     one layer that extends to both sides of the cathode

ENDRELEASENOTES

requires https://github.com/AIDASoft/DD4hep/pull/244