### PR TITLE
fix all compiler warnings (gcc54-up1604)

### DIFF
--- a/include/DDKalTest/DDConeMeasLayer.h
+++ b/include/DDKalTest/DDConeMeasLayer.h
@@ -9,8 +9,9 @@
 #include "iostream"
 #include "streamlog/streamlog.h"
 
-//helper struct serving as private base
-namespace{
+// helper struct serving as private base
+// needed in order to use the the members in initialization list
+namespace DDConeMeasLayer_Base{
   struct Data{
     Double_t _Z1;      // z of front face
     Double_t _R1;      // r of front face
@@ -27,7 +28,7 @@ namespace{
  *  @date Nov 2015
  *  @version $Id:$
  */
-class DDConeMeasLayer : public DDVMeasLayer, private Data, public TCutCone {
+class DDConeMeasLayer : public DDVMeasLayer, private DDConeMeasLayer_Base::Data, public TCutCone {
 public:
   // Ctors and Dtor
   /// Constructor: initialize with Surface and B-field
@@ -97,13 +98,8 @@ public:
 
    
 private:
-  // Double_t fZ1;      // z of front face
-  // Double_t fR1;      // r of front face
-  // Double_t fZ2;      // z of back end
-  // Double_t fR2;      // r of back end
-  Double_t fsortingPolicy; // used for sorting the layers in to out
 
-  
+  Double_t fsortingPolicy; // used for sorting the layers in to out
 };
 
 #endif

--- a/include/DDKalTest/DDCylinderHit.h
+++ b/include/DDKalTest/DDCylinderHit.h
@@ -1,9 +1,10 @@
 #ifndef DDCYLINDERHIT_H
 #define DDCYLINDERHIT_H
 
-/** DDCylinderHit: User defined KalTest hit class using R and Rphi coordinates, which provides coordinate vector as defined by the MeasLayer 
+/** DDCylinderHit: User defined KalTest hit class using R and Rphi coordinates,
+ *  which provides coordinate vector as defined by the MeasLayer
  *
- * @author S.Aplin DESY
+ * @author  F.Gaede, S.Aplin DESY
  */
 
 #include "kaltest/KalTrackDim.h"
@@ -16,10 +17,9 @@ public:
   
   
   /** Constructor Taking R and Rphi coordinates and associated measurement layer, with bfield */
-  DDCylinderHit(const TVMeasLayer &ms, Double_t *x, Double_t *dx, 
-                 Double_t bfield, EVENT::TrackerHit* trkhit ) 
-  : DDVTrackHit(ms, x, dx, bfield, 2, trkhit)
-  { /* no op */ } 
+ DDCylinderHit(const TVMeasLayer &ms, Double_t *x, Double_t *dx,
+	       Double_t bfield, const EVENT::TrackerHit* trkhit )
+   : DDVTrackHit(ms, x, dx, bfield, 2, trkhit) {}
     
   
   // TVTrackHit's pure virtuals that must be implemented
@@ -28,11 +28,7 @@ public:
   virtual TKalMatrix XvToMv(const TVector3 &xv, Double_t t0) const;
   
   /** Print Debug information */
-  virtual void       DebugPrint(Option_t *opt = "")         const;
-  
-  
-private:
-  
+  virtual void  DebugPrint(Option_t *opt = "") const;
   
 };
 #endif

--- a/include/DDKalTest/DDCylinderMeasLayer.h
+++ b/include/DDKalTest/DDCylinderMeasLayer.h
@@ -58,7 +58,7 @@ public:
   virtual TKalMatrix XvToMv    (const TVector3   &xv)   const;
   
   /** Global to Local coordinates */
-  virtual TKalMatrix XvToMv    (const TVTrackHit &ht,
+  virtual TKalMatrix XvToMv    (const TVTrackHit &/*ht*/,
                                 const TVector3   &xv)   const 
   
   { return this->XvToMv(xv); }  
@@ -82,7 +82,7 @@ public:
                                        TVector3 &xx,
                                        Double_t &phi,
                                        Int_t    &CellID,
-                                       Int_t     mode,
+                                       Int_t     /*mode*/,
                                        Double_t  eps = 1.e-8) const {
     
     int ret = this->CalcXingPointWith(hel,xx,phi,0,eps) ;
@@ -96,8 +96,8 @@ public:
   Double_t GetSortingPolicy() const { return fSortingPolicy; }
  
 protected:
-  unsigned fMDim ;
   Double_t fSortingPolicy;
+  unsigned fMDim ;
   
 private:
   

--- a/include/DDKalTest/DDPlanarHit.h
+++ b/include/DDKalTest/DDPlanarHit.h
@@ -19,7 +19,7 @@ public:
 	      Double_t           *x,
 	      Double_t           *dx,
 	      Double_t           bfield,
-	      EVENT::TrackerHit* trkhit,
+	      const EVENT::TrackerHit* trkhit,
 	      unsigned dimension ) 
     : DDVTrackHit(ms, x, dx, bfield, dimension ,trkhit)
   { /* no op */ } 

--- a/include/DDKalTest/DDVMeasLayer.h
+++ b/include/DDKalTest/DDVMeasLayer.h
@@ -35,7 +35,10 @@ namespace EVENT{
  */
 class DDVMeasLayer : public TVMeasLayer {
 public:
-  
+
+  DDVMeasLayer(const DDVMeasLayer&) = delete ;
+  DDVMeasLayer& operator=(const DDVMeasLayer&) = delete ;
+
   static Bool_t kActive;
   static Bool_t kDummy;
   
@@ -111,13 +114,13 @@ protected:
   
   
   
-  Double_t _Bz ;       // Magnitude of B-Field in Z
-  int _layerID ;
-  std::vector<int> _cellIDs ;
+  Double_t _Bz = 0. ;       // Magnitude of B-Field in Z
+  int _layerID = 0 ;
+  std::vector<int> _cellIDs{} ;
 
-  bool _isMultiLayer;
+  bool _isMultiLayer = false ;
 
-  DDSurfaces::ISurface* _surf ;
+  const DDSurfaces::ISurface* _surf ;
   
 };
 

--- a/include/DDKalTest/DDVTrackHit.h
+++ b/include/DDKalTest/DDVTrackHit.h
@@ -1,9 +1,10 @@
-#ifndef DDVTrackHIT_H
-#define DDVTrackHIT_H
+#ifndef DDVTrackHit_H
+#define DDVTrackHit_H
 
-/** DDVMeasLayer:  Virtual hit class used by DD[X]Hit Classes, which should provide coordinate vector as defined by the MeasLayer
+/** DDVMeasLayer:  Virtual hit class used by DD[X]Hit Classes, which should provide coordinate
+ *  vector as defined by the MeasLayer
  *
- * @author S.Aplin DESY
+ * @author F.Gaede, S.Aplin DESY
  */
 
 
@@ -16,19 +17,22 @@
 class DDVTrackHit : public TVTrackHit {
   
 public:
+  DDVTrackHit(const DDVTrackHit&) = default ;
+  DDVTrackHit& operator=(const DDVTrackHit&) = default ;
+
+  /** Constructor Taking coordinates and associated measurement layer,
+   *  with bfield and number of measurement dimentions.
+   */
+ DDVTrackHit(const TVMeasLayer &ms, Double_t *x, Double_t *dx,
+	     Double_t bfield , Int_t dim, const EVENT::TrackerHit* trkhit)
+   : TVTrackHit(ms, x, dx, bfield, dim),
+    _trkhit(trkhit) {
+  }
+
+  const EVENT::TrackerHit* getLCIOTrackerHit() const { return _trkhit; }
+
+ private:
   
-   /** Constructor Taking coordinates and associated measurement layer, with bfield and number of measurement dimentions*/
-  DDVTrackHit(const TVMeasLayer &ms, Double_t *x, Double_t *dx, 
-               Double_t bfield , Int_t dim, EVENT::TrackerHit* trkhit) 
-  : TVTrackHit(ms, x, dx, bfield, dim), _trkhit(trkhit)
-  { /* no op */ }
-  
-  EVENT::TrackerHit* getLCIOTrackerHit() const { return _trkhit; }
-  
-  
-private:
-  
-  EVENT::TrackerHit* _trkhit;
-  
+  const EVENT::TrackerHit* _trkhit = nullptr ;
 };
 #endif

--- a/src/DDCylinderHit.cc
+++ b/src/DDCylinderHit.cc
@@ -21,7 +21,7 @@ using std::resetiosflags;
 
 /** Global to Local coordinates */
 
-TKalMatrix DDCylinderHit::XvToMv(const TVector3 &xv, Double_t t0) const
+TKalMatrix DDCylinderHit::XvToMv(const TVector3 &xv, Double_t /*t0*/) const
 {
   
   return this->GetMeasLayer().XvToMv(*(this), xv);

--- a/src/DDCylinderMeasLayer.cc
+++ b/src/DDCylinderMeasLayer.cc
@@ -175,7 +175,7 @@ TVector3 DDCylinderMeasLayer::HitToXv(const TVTrackHit &vht) const
 
 /** Calculate Projector Matrix */
 
-void DDCylinderMeasLayer::CalcDhDa(const TVTrackHit &vht, // tracker hit not used here
+void DDCylinderMeasLayer::CalcDhDa(const TVTrackHit &/*vht*/, // not used here
                                     const TVector3   &xxv,
                                     const TKalMatrix &dxphiada,
                                     TKalMatrix &H) const
@@ -324,7 +324,7 @@ Int_t DDCylinderMeasLayer::CalcXingPointWith(const TVTrack  &hel,
 					     TVector3 &xx,
 					     Double_t &phi,
 					     Int_t     mode,
-					     Double_t  eps) const {
+					     Double_t  /*eps*/) const {
   
   // check that direction has one of the correct values
   if( !( mode == 0 || mode == 1 || mode == -1) ) return -1 ;
@@ -344,7 +344,6 @@ Int_t DDCylinderMeasLayer::CalcXingPointWith(const TVTrack  &hel,
   Double_t kappa  = hel.GetKappa();
   Double_t rho    = hel.GetRho();
   Double_t omega  = 1.0 / rho;
-  Double_t r      = TMath::Abs(rho);
   Double_t z0     = hel.GetDz();
   Double_t tanl   = hel.GetTanLambda();
   
@@ -467,10 +466,6 @@ Int_t DDCylinderMeasLayer::CalcXingPointWith(const TVTrack  &hel,
       return 0;
     }
   }
-
-
-
-  //  return TCylinder::CalcXingPointWith( hel,xx,phi,mode,eps) ;
 
   return (IsOnSurface(xx) ? 1 : 0);
 }

--- a/src/DDParallelPlanarMeasLayer.cc
+++ b/src/DDParallelPlanarMeasLayer.cc
@@ -32,7 +32,7 @@ Int_t DDParallelPlanarMeasLayer::CalcXingPointWith(const TVTrack  &hel,
                                                     TVector3 &xx,
                                                     Double_t &phi,
                                                     Int_t     mode,
-                                                    Double_t  eps) const {
+						    Double_t  /*eps*/) const {
 
   // check that direction has one of the correct values
   if( !( mode == 0 || mode == 1 || mode == -1) ) return -1 ;
@@ -52,7 +52,6 @@ Int_t DDParallelPlanarMeasLayer::CalcXingPointWith(const TVTrack  &hel,
   Double_t kappa  = hel.GetKappa();
   Double_t rho    = hel.GetRho();
   Double_t omega  = 1.0 / rho;
-  Double_t r      = TMath::Abs(rho);
   Double_t z0     = hel.GetDz();
   Double_t tanl   = hel.GetTanLambda();
   

--- a/src/DDPlanarMeasLayer.cc
+++ b/src/DDPlanarMeasLayer.cc
@@ -40,7 +40,7 @@ DDPlanarMeasLayer::DDPlanarMeasLayer(dd4hep::rec::ISurface* surf, Double_t   Bz,
 
   static int count=0 ;
   static const double epsilon=1e-6 ;
-  static const double epsZ=1e-8 ;
+  //  static const double epsZ=1e-8 ;
   
   //fg: the sorting policy is used to find the measurment layers that are going to be hit by a track ...
   //    simply add an epslion to the radius in order to have a loop over all sensors in a layer
@@ -170,7 +170,7 @@ TVector3 DDPlanarMeasLayer::HitToXv(const TVTrackHit &vht) const {
 }
 
 
-void DDPlanarMeasLayer::CalcDhDa(const TVTrackHit &vht,
+void DDPlanarMeasLayer::CalcDhDa(const TVTrackHit &/*vht*/,
 				 const TVector3   &xxv,
 				 const TKalMatrix &dxphiada,
 				 TKalMatrix &H)  const {
@@ -244,7 +244,7 @@ int DDPlanarMeasLayer::getIntersectionAndCellID(const TVTrack  &hel,
 						TVector3 &xx,
 						Double_t &phi,
 						Int_t    &CellID,
-						Int_t     mode,
+						Int_t     /*mode*/,
 						Double_t  eps ) const {
   
   CellID = this->getCellIDs()[0]; // not multilayer
@@ -257,24 +257,11 @@ DDVTrackHit* DDPlanarMeasLayer::ConvertLCIOTrkHit( EVENT::TrackerHit* trkhit) co
   EVENT::TrackerHitPlane* plane_hit = dynamic_cast<EVENT::TrackerHitPlane*>( trkhit ) ;
   
   if( plane_hit == NULL ){
-    streamlog_out( ERROR ) << " DDPlanarMeasLayer::ConvertLCIOTrkHit called with something that isn't an EVENT::TrackerHitPlane : " << *trkhit << std::endl ;
+    streamlog_out( ERROR ) << " DDPlanarMeasLayer::ConvertLCIOTrkHit"
+			   << " called with something that isn't an EVENT::TrackerHitPlane : "
+			   << *trkhit << std::endl ;
     return NULL; 
   }
-  
-  
-  // get the measurment durections from the surface ( should of course be identical to the ones in the lcio hit ...)
-  dd4hep::rec::Vector3D u = _surf->u() ;
-  dd4hep::rec::Vector3D v = _surf->v() ;
-  
-  // dd4hep::rec::Vector3D U(1.0,plane_hit->getU()[1],plane_hit->getU()[0],dd4hep::rec::Vector3D::spherical);
-  // dd4hep::rec::Vector3D V(1.0,plane_hit->getV()[1],plane_hit->getV()[0],dd4hep::rec::Vector3D::spherical);
-  // dd4hep::rec::Vector3D Z(0.0,0.0,1.0);
-  // streamlog_out(DEBUG1) << "DDPlanarMeasLayer::ConvertLCIOTrkHit : " 
-  // 			// << "\n U : " << U  
-  // 			<< "\n u : " << u 
-  // 			<< "\n V : " << V 
-  // 			<< "\n v : " << v
-  // 			<< std::endl ; 
   
   // remember here the "position" of the hit in fact defines the origin of the plane it defines so u and v are per definition 0. 
   const TVector3 hit( plane_hit->getPosition()[0], plane_hit->getPosition()[1], plane_hit->getPosition()[2]) ;

--- a/src/DDVMeasLayer.cc
+++ b/src/DDVMeasLayer.cc
@@ -39,9 +39,8 @@ DDVMeasLayer::DDVMeasLayer( DDSurfaces::ISurface* surf,
 	      MaterialMap::get( surf->outerMaterial() ) ,
 	      surf->type().isSensitive(), 
 	      name),
-  _surf( surf) ,
   _Bz(Bz),
-  _isMultiLayer(false) {
+  _surf( surf) {
   
   unsigned cellID = surf->id() ;
   _cellIDs.push_back( cellID );
@@ -64,10 +63,9 @@ DDVMeasLayer::DDVMeasLayer( DDSurfaces::ISurface* surf,
 			    int        cellID ,
 			    const Char_t    *name)  
   : TVMeasLayer(min, mout, is_active, name),
-    _surf( surf) ,
     _Bz(Bz),
-    _isMultiLayer(false)
-{
+    _surf( surf) {
+
   _cellIDs.push_back(cellID);
   
   UTIL::BitField64 encoder( UTIL::LCTrackerCellID::encoding_string() ) ; 
@@ -88,11 +86,10 @@ DDVMeasLayer::DDVMeasLayer(  DDSurfaces::ISurface* surf,
                              Bool_t    is_active,
                              const Char_t    *name)
   : TVMeasLayer(min, mout, is_active, name),
-    _surf( surf) ,
     _Bz(Bz),
     _cellIDs(cellIDs),
-    _isMultiLayer(true)
-{
+    _isMultiLayer(true),
+    _surf( surf) {
   
   if (cellIDs.size() == 0 ) {
     streamlog_out(ERROR) << __FILE__ << " line " << __LINE__ << " size of cellIDs == 0" << std::endl;
@@ -180,12 +177,9 @@ Double_t DDVMeasLayer::GetEnergyLoss( Bool_t    isoutgoing,
   bool use_aidaTT = false ;
   if( use_aidaTT ){  // ----------------------------------------------
     Double_t dr     = hel.GetDrho();
-    //Double_t kappa  = hel.GetKappa();
     Double_t rho    = hel.GetRho();
     Double_t omega  = 1.0 / rho;
-    //  Double_t r      = TMath::Abs(rho);
     Double_t z0     = hel.GetDz();
-    Double_t tanl   = hel.GetTanLambda();
     double d0 = - dr ;
     double phi0_lcio =  toBaseRange( phi0 + M_PI/2. );
     TVector3 ref_point = hel.GetPivot(); 
@@ -312,9 +306,9 @@ Double_t DDVMeasLayer::GetEnergyLoss( Bool_t    isoutgoing,
 //    calculates process noise matrix for multiple scattering with
 //    thin layer approximation.
 //
-void DDVMeasLayer::CalcQms( Bool_t        isoutgoing,
+void DDVMeasLayer::CalcQms( Bool_t        /*isoutgoing*/,
 			    const TVTrack &hel,
-			    Double_t      df,
+			    Double_t      /*df*/,
 			    TKalMatrix    &Qms) const
 {
   Double_t cpa    = hel.GetKappa();


### PR DESCRIPTION
BEGINRELEASENOTES
- fix all compiler warnings (gcc54-ub1604)
- use const ptr for lcio::TrackerHit and dd4hep::Surface

ENDRELEASENOTES