### PR TITLE
Adopt for cleaning of DD4hep

### DIFF
--- a/include/DDKalTest/DDConeMeasLayer.h
+++ b/include/DDKalTest/DDConeMeasLayer.h
@@ -22,7 +22,7 @@ namespace DDConeMeasLayer_Base{
 }
 
 /** DDConeMeasLayer provides a conical helper layer (no measurements )
- *  using a DDSurfaces::ISurface.
+ *  using a dd4hep::rec::ISurface.
  *  
  *  @author F.Gaede DESY
  *  @date Nov 2015
@@ -32,7 +32,7 @@ class DDConeMeasLayer : public DDVMeasLayer, private DDConeMeasLayer_Base::Data,
 public:
   // Ctors and Dtor
   /// Constructor: initialize with Surface and B-field
-  DDConeMeasLayer(DDSurfaces::ISurface* surf,
+  DDConeMeasLayer(dd4hep::rec::ISurface* surf,
 		  Double_t   Bz,
 		  const Char_t    *name = "DDConeMeasL") ; 
 

--- a/include/DDKalTest/DDCylinderMeasLayer.h
+++ b/include/DDKalTest/DDCylinderMeasLayer.h
@@ -6,10 +6,10 @@
 #include <cmath>
 //#include "streamlog/streamlog.h"
 
-#include "DDSurfaces/ISurface.h"
+#include "DDRec/ISurface.h"
 
 /** DDCylinderMeasLayer provides a generic planar measurement for 1-dim and 2-dim hits
- *  using a DDSurfaces::ISurface.
+ *  using a dd4hep::rec::ISurface.
  *  
  *  @author F.Gaede CERN/DESY
  *  @date Feb 2015
@@ -20,7 +20,7 @@ class DDCylinderMeasLayer : public DDVMeasLayer, public TCylinder {
 public:
   
   /// Constructor: initialize with Surface and B-field
-  DDCylinderMeasLayer(DDSurfaces::ISurface* surf,
+  DDCylinderMeasLayer(dd4hep::rec::ISurface* surf,
 		      Double_t   Bz,
 		      const Char_t    *name = "DDCylinderMeasL") ; 
   

--- a/include/DDKalTest/DDDiscMeasLayer.h
+++ b/include/DDKalTest/DDDiscMeasLayer.h
@@ -5,7 +5,7 @@
 
 
 /** DDDiscMeasLayer: specialization of DDPlanarMeasruement layer 
- *  As we use the DDSurfaces::ISurface and aidaTT::trajectory for the implementation 
+ *  As we use the DDRec::ISurface and aidaTT::trajectory for the implementation
  *  of CalcXingPointWith() and the disctinction between parallel and orthogonal
  *  planes is done there, this class is currently identical to  DDParallelPlanarMeasLayer
  *  and we simply create a typedef for now.

--- a/include/DDKalTest/DDParallelPlanarMeasLayer.h
+++ b/include/DDKalTest/DDParallelPlanarMeasLayer.h
@@ -2,13 +2,13 @@
 #define __DDParallelPlanarMeasLayer__
 
 #include "DDPlanarMeasLayer.h"
-#include "DDSurfaces/ISurface.h"
+#include "DDRec/ISurface.h"
 
 
 /** DDParallelPlanarMeasLayer: specialization of DDPlanarMeasruement layer 
  *  for planes that are parallel to the z-axis, where the crossing point
  *  with a helix can be comuted analytically. 
- *  We use the DDSurfaces::ISurface and aidaTT::trajectory for the implementation 
+ *  We use the dd4hep::rec::ISurface and aidaTT::trajectory for the implementation
  *  of CalcXingPointWith(). 
  * 
  * @author F. Gaede CERN/DESY, S.Aplin DESY
@@ -20,7 +20,7 @@ class DDParallelPlanarMeasLayer : public DDPlanarMeasLayer {
 public:
   
   /// c'tor using a DDRec::Surface
-  DDParallelPlanarMeasLayer( DDSurfaces::ISurface* surf, Double_t   Bz) :  DDPlanarMeasLayer( surf , Bz )  {}
+  DDParallelPlanarMeasLayer( dd4hep::rec::ISurface* surf, Double_t   Bz) :  DDPlanarMeasLayer( surf , Bz )  {}
 
   
   // Parent's pure virtuals that must be implemented

--- a/include/DDKalTest/DDPlanarMeasLayer.h
+++ b/include/DDKalTest/DDPlanarMeasLayer.h
@@ -4,13 +4,13 @@
 #include "DDVMeasLayer.h"
 #include "TPlane.h"
 
-#include "DDSurfaces/ISurface.h"
+#include "DDRec/ISurface.h"
 
 class TVTrackHit;
 class TVector3 ;
 
 /** DDPlanarMeasLayer provides a generic planar measurment for 1-dim and 2-dim hits
- *  using a DDSurfaces::ISurface.
+ *  using a dd4hep::rec::ISurface.
  *  
  *  @author F.Gaede CERN/DESY
  *  @date Dec 2014
@@ -21,7 +21,7 @@ class DDPlanarMeasLayer : public DDVMeasLayer, public TPlane {
 public:
 
   /// Ctor: initialize with Surface
-  DDPlanarMeasLayer( DDSurfaces::ISurface* surf,
+  DDPlanarMeasLayer( dd4hep::rec::ISurface* surf,
 		     Double_t   Bz,		    
 		     const Char_t  *name = "DDPlanarMeasL");
   

--- a/include/DDKalTest/DDVMeasLayer.h
+++ b/include/DDKalTest/DDVMeasLayer.h
@@ -9,7 +9,7 @@
 #include "kaltest/KalTrackDim.h"
 #include "TString.h"
 
-#include "DDSurfaces/ISurface.h"
+#include "DDRec/ISurface.h"
 
 #include <vector>
 
@@ -22,7 +22,7 @@ namespace EVENT{
 }
 
 /** DDVMeasLayer: Virtual measurement layer class used by DD[X]MeasLayer Classes.
- *  Main methods are GetEnergyLoss() and CalcQms() which both use the DDSurfaces::ISurface
+ *  Main methods are GetEnergyLoss() and CalcQms() which both use the dd4hep::rec::ISurface
  *  and compute energy loss and material from the inner and outer materials assigned
  *  to this surface.
  *  The main difference to the implementation in KalTest::TVMeasLayer is that only
@@ -87,16 +87,16 @@ public:
 			Double_t  df,
 			TKalMatrix  &Qms) const ;
     
-  const DDSurfaces::ISurface* surface() const { return _surf ; }
+  const dd4hep::rec::ISurface* surface() const { return _surf ; }
 
 protected:
   
   ///Simple c'tor that takes a surface, the b-field and a name - should be the only one !?
-  DDVMeasLayer( DDSurfaces::ISurface* surf,
+  DDVMeasLayer( dd4hep::rec::ISurface* surf,
 		Double_t   Bz,
 		const Char_t    *name) ;
 
-  DDVMeasLayer( DDSurfaces::ISurface* surf,
+  DDVMeasLayer( dd4hep::rec::ISurface* surf,
 		TMaterial &min,
                 TMaterial &mout,
                 Double_t  Bz,
@@ -104,7 +104,7 @@ protected:
                 int CellID = -1 , 
                 const Char_t    *name = "DDMeasL");
   
-  DDVMeasLayer( DDSurfaces::ISurface* surf,
+  DDVMeasLayer( dd4hep::rec::ISurface* surf,
 		TMaterial &min,
 	        TMaterial &mout,
                 Double_t  Bz,
@@ -120,7 +120,7 @@ protected:
 
   bool _isMultiLayer = false ;
 
-  const DDSurfaces::ISurface* _surf ;
+  const dd4hep::rec::ISurface* _surf ;
   
 };
 

--- a/include/DDKalTest/MaterialMap.h
+++ b/include/DDKalTest/MaterialMap.h
@@ -4,14 +4,14 @@
 #include <map>
 #include <string>
 
-#include "DDSurfaces/IMaterial.h"
+#include "DDRec/IMaterial.h"
 
 #include "streamlog/streamlog.h"
 
 #include "TMaterial.h"
 
 /** Singleton map for holding TMaterial objects, created 
- *  from DDSurfaces::IMaterial objects - assumes that material names 
+ *  from dd4hep::rec::IMaterial objects - assumes that material names
  *  are unique.
  *
  * @author F.Gaede CERN/DESY
@@ -24,7 +24,7 @@ class MaterialMap {
 
 public:
   
-  static TMaterial& get( const DDSurfaces::IMaterial& mat ){
+  static TMaterial& get( const dd4hep::rec::IMaterial& mat ){
 
     static MAP _map ;
 

--- a/include/DDKalTest/attic/DDParallelPlanarStripMeasLayer.h
+++ b/include/DDKalTest/attic/DDParallelPlanarStripMeasLayer.h
@@ -27,7 +27,7 @@ public:
     double angle = surf->v().theta() * 2. ; // FIXME: had 3.5 in SIT_SimplePlanar_geo !!!
     
     // check sign of rotation via helper vector cerated from cross product w/ z-axis
-    DDSurfaces::Vector3D n  =  surf->v().cross(  DDSurfaces::Vector3D( 0, 0, 1.)  ) ;
+    dd4hep::rec::Vector3D n  =  surf->v().cross(  dd4hep::rec::Vector3D( 0, 0, 1.)  ) ;
     
     // does this point into the same hemisphere as the normal ?
     double ndot = n.dot( surf->normal()  ) ; 

--- a/src/DDConeMeasLayer.cc
+++ b/src/DDConeMeasLayer.cc
@@ -1,7 +1,7 @@
 #include "DDKalTest/DDConeMeasLayer.h"
 #include <UTIL/LCTrackerConf.h>
 #include "DD4hep/DD4hepUnits.h"
-#include "DDSurfaces/Vector3D.h"
+#include "DDRec/Vector3D.h"
 
 #include "TVTrack.h"
 
@@ -18,14 +18,14 @@
 //}
 
 
-DDConeMeasLayer::DDConeMeasLayer(DDSurfaces::ISurface* surf,
+DDConeMeasLayer::DDConeMeasLayer(dd4hep::rec::ISurface* surf,
 				 Double_t   Bz,
 				 const Char_t  *name ) :
   DDVMeasLayer(  surf, Bz, name ) ,
-  Data(dynamic_cast<DDSurfaces::ICone*>(surf)->z0()/dd4hep::mm ,
-       dynamic_cast<DDSurfaces::ICone*>(surf)->radius0()/dd4hep::mm,
-       dynamic_cast<DDSurfaces::ICone*>(surf)->z1()/dd4hep::mm,
-       dynamic_cast<DDSurfaces::ICone*>(surf)->radius1()/dd4hep::mm ),
+  Data(dynamic_cast<dd4hep::rec::ICone*>(surf)->z0()/dd4hep::mm ,
+       dynamic_cast<dd4hep::rec::ICone*>(surf)->radius0()/dd4hep::mm,
+       dynamic_cast<dd4hep::rec::ICone*>(surf)->z1()/dd4hep::mm,
+       dynamic_cast<dd4hep::rec::ICone*>(surf)->radius1()/dd4hep::mm ),
   TCutCone(_R1*(_Z2-_Z1)/(_R2-_R1), 
    	   _R2*(_Z2-_Z1)/(_R2-_R1), 
    	   (_R2-_R1)/(_Z2-_Z1),

--- a/src/DDCylinderMeasLayer.cc
+++ b/src/DDCylinderMeasLayer.cc
@@ -10,7 +10,7 @@
 #include <UTIL/Operators.h>
 
 #include "DD4hep/DD4hepUnits.h"
-#include "DDSurfaces/Vector3D.h"
+#include "DDRec/Vector3D.h"
 
 #include "aidaTT/trajectory.hh"
 
@@ -30,16 +30,16 @@ namespace{
 
 using namespace UTIL ;
 
-DDCylinderMeasLayer::DDCylinderMeasLayer(DDSurfaces::ISurface* surf,
+DDCylinderMeasLayer::DDCylinderMeasLayer(dd4hep::rec::ISurface* surf,
 					 Double_t   Bz,
 					 const Char_t  *name ) :
   DDVMeasLayer(  surf, Bz, name ) ,
   
-  TCylinder(  dynamic_cast<DDSurfaces::ICylinder*>(surf)->radius()/dd4hep::mm , 
+  TCylinder(  dynamic_cast<dd4hep::rec::ICylinder*>(surf)->radius()/dd4hep::mm ,
 	      surf->length_along_v()/dd4hep::mm / 2. , 
-	      dynamic_cast<DDSurfaces::ICylinder*>(surf)->center().x()/dd4hep::mm, 
-	      dynamic_cast<DDSurfaces::ICylinder*>(surf)->center().y()/dd4hep::mm , 
-	      dynamic_cast<DDSurfaces::ICylinder*>(surf)->center().z()/dd4hep::mm ),
+	      dynamic_cast<dd4hep::rec::ICylinder*>(surf)->center().x()/dd4hep::mm,
+	      dynamic_cast<dd4hep::rec::ICylinder*>(surf)->center().y()/dd4hep::mm ,
+	      dynamic_cast<dd4hep::rec::ICylinder*>(surf)->center().z()/dd4hep::mm ),
   
   fSortingPolicy(0.),
   
@@ -58,7 +58,7 @@ DDCylinderMeasLayer::DDCylinderMeasLayer(DDSurfaces::ISurface* surf,
     _cellIDs.push_back( encoder.lowWord() ) ;
   }
 
-  fSortingPolicy = dynamic_cast<DDSurfaces::ICylinder*>(surf)->radius()/dd4hep::mm + side * epsilon ;
+  fSortingPolicy = dynamic_cast<dd4hep::rec::ICylinder*>(surf)->radius()/dd4hep::mm + side * epsilon ;
 
   // assumptions made here: the cylinder runs parallel to z and v ...
   
@@ -107,8 +107,8 @@ TKalMatrix DDCylinderMeasLayer::XvToMv(const TVector3 &xv) const
 
   TKalMatrix mv( fMDim , 1 );
   
-  DDSurfaces::Vector2D lv = _surf->globalToLocal( DDSurfaces::Vector3D( xv.X()*dd4hep::mm ,  
-									xv.Y()*dd4hep::mm ,  
+  dd4hep::rec::Vector2D lv = _surf->globalToLocal( dd4hep::rec::Vector3D( xv.X()*dd4hep::mm ,
+									xv.Y()*dd4hep::mm ,
 									xv.Z()*dd4hep::mm ) ) ;
   
   mv(0,0) = lv[0] / dd4hep::mm ; 
@@ -144,9 +144,9 @@ TVector3 DDCylinderMeasLayer::HitToXv(const TVTrackHit &vht) const
   // Double_t y0   = GetR() * TMath::Sin(phi) + GetXc().Y();
   // return TVector3(x, y, z);
 
-  DDSurfaces::Vector3D v = ( fMDim == 2 ? 
-			     _surf->localToGlobal( DDSurfaces::Vector2D (  vht(0,0)*dd4hep::mm, vht(1,0) *dd4hep::mm ) )  :
-			     _surf->localToGlobal( DDSurfaces::Vector2D (  vht(0,0)*dd4hep::mm,    0.  ) ) 
+  dd4hep::rec::Vector3D v = ( fMDim == 2 ?
+			     _surf->localToGlobal( dd4hep::rec::Vector2D (  vht(0,0)*dd4hep::mm, vht(1,0) *dd4hep::mm ) )  :
+			     _surf->localToGlobal( dd4hep::rec::Vector2D (  vht(0,0)*dd4hep::mm,    0.  ) )
 			     ) ;
   
   double x = v[0] / dd4hep::mm ;
@@ -216,17 +216,17 @@ void DDCylinderMeasLayer::CalcDhDa(const TVTrackHit &/*vht*/, // not used here
   
 #else // ---- new code using surfaces 
 
-  DDSurfaces::Vector3D u = _surf->u(  DDSurfaces::Vector3D( xxv.x(),xxv.Y(),xxv.Z() ) ) ;
-  DDSurfaces::Vector3D v = _surf->v(  DDSurfaces::Vector3D( xxv.x(),xxv.Y(),xxv.Z() ) ) ;
+  dd4hep::rec::Vector3D u = _surf->u(  dd4hep::rec::Vector3D( xxv.x(),xxv.Y(),xxv.Z() ) ) ;
+  dd4hep::rec::Vector3D v = _surf->v(  dd4hep::rec::Vector3D( xxv.x(),xxv.Y(),xxv.Z() ) ) ;
   
   double uv = u * v ;
-  DDSurfaces::Vector3D uprime = ( u - uv * v ).unit() ; 
-  DDSurfaces::Vector3D vprime = ( v - uv * u ).unit() ; 
+  dd4hep::rec::Vector3D uprime = ( u - uv * v ).unit() ;
+  dd4hep::rec::Vector3D vprime = ( v - uv * u ).unit() ;
   double uup = u * uprime ;
   double vvp = v * vprime ;
   
-  DDSurfaces::Vector3D dudx =  1./uup * uprime  ;
-  DDSurfaces::Vector3D dvdx =  1./vvp * vprime;
+  dd4hep::rec::Vector3D dudx =  1./uup * uprime  ;
+  dd4hep::rec::Vector3D dvdx =  1./vvp * vprime;
   
   //------------------------------------------------------
   

--- a/src/DDPlanarMeasLayer.cc
+++ b/src/DDPlanarMeasLayer.cc
@@ -10,7 +10,7 @@
 #include "DD4hep/Volumes.h"
 
 #include "DDRec/Surface.h"
-#include "DDSurfaces/Vector3D.h"
+#include "DDRec/Vector3D.h"
 
 #include <EVENT/TrackerHitPlane.h>
 #include <UTIL/Operators.h>

--- a/src/DDVMeasLayer.cc
+++ b/src/DDVMeasLayer.cc
@@ -31,7 +31,7 @@ namespace{
 
 
 
-DDVMeasLayer::DDVMeasLayer( DDSurfaces::ISurface* surf,
+DDVMeasLayer::DDVMeasLayer( dd4hep::rec::ISurface* surf,
 			    Double_t   Bz,
 			    const Char_t    *name)  
   : 
@@ -55,7 +55,7 @@ DDVMeasLayer::DDVMeasLayer( DDSurfaces::ISurface* surf,
 }
 
 
-DDVMeasLayer::DDVMeasLayer( DDSurfaces::ISurface* surf,
+DDVMeasLayer::DDVMeasLayer( dd4hep::rec::ISurface* surf,
 			    TMaterial &min,
 			    TMaterial &mout,
 			    Double_t   Bz,
@@ -78,7 +78,7 @@ DDVMeasLayer::DDVMeasLayer( DDSurfaces::ISurface* surf,
 }
 
 
-DDVMeasLayer::DDVMeasLayer(  DDSurfaces::ISurface* surf,
+DDVMeasLayer::DDVMeasLayer(  dd4hep::rec::ISurface* surf,
 			     TMaterial &min,
                              TMaterial &mout,
                              Double_t  Bz,
@@ -200,13 +200,13 @@ Double_t DDVMeasLayer::GetEnergyLoss( Bool_t    isoutgoing,
     //    across the thickness of the surface
     //    also assumes that the reference point is near by 
     //    -fixme: check these conditions !
-    DDSurfaces::Vector3D p( - std::sin( phi0 ), std::cos( phi0 ) , tnl ) ;
-    DDSurfaces::Vector3D up = p.unit() ;
+    dd4hep::rec::Vector3D p( - std::sin( phi0 ), std::cos( phi0 ) , tnl ) ;
+    dd4hep::rec::Vector3D up = p.unit() ;
     
     // need to get the normal at crossing point ( should be the current helix' reference point) 
     const TVector3& piv = hel.GetPivot() ;
-    DDSurfaces::Vector3D xx( piv.X()*dd4hep::mm,piv.Y()*dd4hep::mm,piv.Z()*dd4hep::mm) ;
-    const DDSurfaces::Vector3D& n = _surf->normal(xx) ;
+    dd4hep::rec::Vector3D xx( piv.X()*dd4hep::mm,piv.Y()*dd4hep::mm,piv.Z()*dd4hep::mm) ;
+    const dd4hep::rec::Vector3D& n = _surf->normal(xx) ;
     
     Double_t cosTrk = std::fabs( up * n )  ;
     
@@ -333,8 +333,8 @@ void DDVMeasLayer::CalcQms( Bool_t        /*isoutgoing*/,
 
   // average the X0 of the inner and outer materials:
   // could also move to c'tor and cache value ...
-  const DDSurfaces::IMaterial& mat_i = _surf->innerMaterial() ;
-  const DDSurfaces::IMaterial& mat_o = _surf->outerMaterial() ;
+  const dd4hep::rec::IMaterial& mat_i = _surf->innerMaterial() ;
+  const dd4hep::rec::IMaterial& mat_o = _surf->outerMaterial() ;
   double x_i = mat_i.radiationLength() ;
   double x_o = mat_o.radiationLength() ;
   double l_i = _surf->innerThickness() ;
@@ -344,13 +344,13 @@ void DDVMeasLayer::CalcQms( Bool_t        /*isoutgoing*/,
 
   //compute path as projection of (straight) track to surface normal:
   Double_t phi0   = hel.GetPhi0();
-  DDSurfaces::Vector3D p( - std::sin( phi0 ), std::cos( phi0 ) , tnl ) ;
-  DDSurfaces::Vector3D up = p.unit() ;
+  dd4hep::rec::Vector3D p( - std::sin( phi0 ), std::cos( phi0 ) , tnl ) ;
+  dd4hep::rec::Vector3D up = p.unit() ;
 
   // need to get the normal at crossing point ( should be the current helix' reference point) 
   const TVector3& piv = hel.GetPivot() ;
-  DDSurfaces::Vector3D xx( piv.X()*dd4hep::mm,piv.Y()*dd4hep::mm,piv.Z()*dd4hep::mm) ;
-  const DDSurfaces::Vector3D& n = _surf->normal( xx ) ;
+  dd4hep::rec::Vector3D xx( piv.X()*dd4hep::mm,piv.Y()*dd4hep::mm,piv.Z()*dd4hep::mm) ;
+  const dd4hep::rec::Vector3D& n = _surf->normal( xx ) ;
 
   Double_t cosTrk = std::fabs( up * n )  ;
   

--- a/src/attic/DDDiscMeasLayer.cc
+++ b/src/attic/DDDiscMeasLayer.cc
@@ -14,7 +14,7 @@
 
 #include <EVENT/TrackerHitPlane.h>
 
-#include "DDSurfaces/Vector3D.h"
+#include "DDRec/Vector3D.h"
 
 #include "streamlog/streamlog.h"
 
@@ -213,10 +213,10 @@ DDVTrackHit* DDDiscMeasLayer::ConvertLCIOTrkHit( EVENT::TrackerHit* trkhit) cons
   
   if( plane_hit == NULL )  return NULL; // SJA:FIXME: should be replaced with an exception  
   
-  DDSurfaces::Vector3D U(1.0,plane_hit->getU()[1],plane_hit->getU()[0],DDSurfaces::Vector3D::spherical);
-  DDSurfaces::Vector3D V(1.0,plane_hit->getV()[1],plane_hit->getV()[0],DDSurfaces::Vector3D::spherical);
-  DDSurfaces::Vector3D X(1.0,0.0,0.0);
-  DDSurfaces::Vector3D Y(0.0,1.0,0.0);
+  dd4hep::rec::Vector3D U(1.0,plane_hit->getU()[1],plane_hit->getU()[0],dd4hep::rec::Vector3D::spherical);
+  dd4hep::rec::Vector3D V(1.0,plane_hit->getV()[1],plane_hit->getV()[0],dd4hep::rec::Vector3D::spherical);
+  dd4hep::rec::Vector3D X(1.0,0.0,0.0);
+  dd4hep::rec::Vector3D Y(0.0,1.0,0.0);
   
   const float eps = 1.0e-07;
   // U must be the global X axis 

--- a/src/attic/DDParallelPlanarStripMeasLayer.cc
+++ b/src/attic/DDParallelPlanarStripMeasLayer.cc
@@ -5,7 +5,7 @@
 
 #include <EVENT/TrackerHitPlane.h>
 
-#include "DDSurfaces/Vector3D.h"
+#include "DDRec/Vector3D.h"
 
 #include "streamlog/streamlog.h"
 


### PR DESCRIPTION
needed for AIDASoft/DD4hep#345
BEGINRELEASENOTES
- Fix for the removal of DDSurfaces which have been merged into DDRec 
  -  includes from `DDSurfaces` -> `DDRec`
  - namespace `DDSurfaces` -> `dd4hep::rec`

ENDRELEASENOTES