### PR TITLE
DDPlanarMeasLayer: add possibility to set Sorting Policy through extension

### DIFF
--- a/src/DDPlanarMeasLayer.cc
+++ b/src/DDPlanarMeasLayer.cc
@@ -43,7 +43,7 @@ DDPlanarMeasLayer::DDPlanarMeasLayer(dd4hep::rec::ISurface* surf, Double_t   Bz,
   //  static const double epsZ=1e-8 ;
   
   //fg: the sorting policy is used to find the measurment layers that are going to be hit by a track ...
-  //    simply add an epslion to the radius in order to have a loop over all sensors in a layer
+  //    simply add an epsilon to the radius in order to have a loop over all sensors in a layer
   //    NB:  this does not deal with the overlap region, e.g. in the VTX
   //         so in this region we might loose one of two hits on a layer
   //         -> to be done ...
@@ -68,8 +68,10 @@ DDPlanarMeasLayer::DDPlanarMeasLayer(dd4hep::rec::ISurface* surf, Double_t   Bz,
     // }
     // this direction would have to be rotated into the local system of the volume
     // but we don't have access to the worlTransfrom matrix here, so
-    // for now we use the y-axis ( works for Traps and Tubs )
-    dd4hep::rec::Vector3D oR( 0. , 1. , 0 );
+    // for now we use the y-axis (works for Traps and Tubs), and z-axis for Trapezoids
+    auto oR = std::string(vol->GetShape()->ClassName()) == "TGeoTrd2" ?
+      dd4hep::rec::Vector3D(0.0, 0.0, 1.0): // "Trapezoids"
+      dd4hep::rec::Vector3D(0.0, 1.0, 0.0); // Other things (Traps following y-Axis conventions, and Tubs)
 
     double dist_r = 0. ;
 

--- a/src/DDPlanarMeasLayer.cc
+++ b/src/DDPlanarMeasLayer.cc
@@ -108,11 +108,17 @@ DDPlanarMeasLayer::DDPlanarMeasLayer(dd4hep::rec::ISurface* surf, Double_t   Bz,
   if(detElement.isValid()) {
     try {
       auto* ext = detElement.extension<dd4hep::rec::DoubleParameters>();
-      fSortingPolicy = ext->doubleParameters.find("SortingPolicy")->second/dd4hep::mm + epsilon * count++;
+      fSortingPolicy = ext->doubleParameters.at("SortingPolicy")/dd4hep::mm + epsilon * count++;
       streamlog_out(DEBUG3) << "Found manual sorting policy for " << detElement.path()
                             << " value [mm] " << fSortingPolicy
                             << std::endl;
-    } catch(...) {
+    } catch(std::runtime_error &) {
+      streamlog_out(DEBUG3) << "Extension DoubleParameters not found for DetElement:"
+                            << detElement.path()
+                            << std::endl;
+    } catch(std::out_of_range &) {
+      streamlog_out(DEBUG3) << "'SortingPolicy' not found in DoubleParameters extension"
+                            << std::endl;
     }
   }
 

--- a/src/DDPlanarMeasLayer.cc
+++ b/src/DDPlanarMeasLayer.cc
@@ -9,6 +9,7 @@
 #include "DD4hep/DD4hepUnits.h"
 #include "DD4hep/Volumes.h"
 
+#include "DDRec/DetectorData.h"
 #include "DDRec/Surface.h"
 #include "DDRec/Vector3D.h"
 
@@ -16,6 +17,7 @@
 #include <UTIL/Operators.h>
 
 #include "streamlog/streamlog.h"
+#include <string>
 
 
 using namespace UTIL ;
@@ -102,6 +104,17 @@ DDPlanarMeasLayer::DDPlanarMeasLayer(dd4hep::rec::ISurface* surf, Double_t   Bz,
     fSortingPolicy =  surf->distance( dd4hep::rec::Vector3D( 0.,0.,0.) )/dd4hep::mm   +  epsilon * count++ ;
   }
 
+  auto detElement = static_cast<dd4hep::rec::Surface*>(surf)->detElement();
+  if(detElement.isValid()) {
+    try {
+      auto* ext = detElement.extension<dd4hep::rec::DoubleParameters>();
+      fSortingPolicy = ext->doubleParameters.find("SortingPolicy")->second/dd4hep::mm + epsilon * count++;
+      streamlog_out(DEBUG3) << "Found manual sorting policy for " << detElement.path()
+                            << " value [mm] " << fSortingPolicy
+                            << std::endl;
+    } catch(...) {
+    }
+  }
 
   streamlog_out(DEBUG1) << "DDPlanarMeasLayer created" 
 			<< " Layer x0 = " << this->GetXc().X() 


### PR DESCRIPTION

BEGINRELEASENOTES
- DDPlanarMeasLayer: use proper "height" to calculate sortingPolicy for DD4hep::Trapezoids, a.k.a. TGeoTrd2
- DDPlanarMeasLayer: if SortingPolicy value is present in the DoubleParameters extension for the DetElement of a surface use that number, plus epsilon.
- Requires AidaSoft/DD4hep#486 to compile, iLCSoft/lcgeo#234 with an example that sets this extension

ENDRELEASENOTES