### PR TITLE
Remove centos7 CI jobs.

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         build_type: ["release", "nightly"]
-        image: ["alma9", "ubuntu22", "centos7"]
+        image: ["alma9", "ubuntu22"]
       fail-fast: false
 
     steps:


### PR DESCRIPTION
Don't try to run CI for centos7.  Builds are no longer available for that platform.

BEGINRELEASENOTES
- Stop trying to run CI jobs on centos7.
ENDRELEASENOTES