### PR TITLE
Fix list of headers to install in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/this${PackageName}.sh
 #--- install target-------------------------------------
 
 
-FILE(GLOB hfiles "ILD/include/*.h")
+FILE(GLOB hfiles "include/DDKalTest/*.h")
 INSTALL(FILES ${hfiles} 
   DESTINATION include/${PackageName} 
   )


### PR DESCRIPTION
The path of headers to install was pointing at a nonexistent directory.  Fix.

BEGINRELEASENOTES
- Properly install headers during build.
ENDRELEASENOTES