### PR TITLE
Fix compilation warnings.

### DIFF
--- a/src/DDConeMeasLayer.cc
+++ b/src/DDConeMeasLayer.cc
@@ -104,16 +104,16 @@ Bool_t DDConeMeasLayer::IsOnSurface(const TVector3 &xx) const {
   Double_t r   = xxc.Perp();
   Double_t z   = xxc.Z();
   Double_t s   = (r - GetTanA()*z) * (r + GetTanA()*z);
-  const Double_t kTol = 1.e-8;
+  const Double_t tol = 1.e-8;
 
 #if 0 
   std::cout << this->TVMeasLayer::GetName() << ":" << this->GetIndex() << ":" 
 	    << "s=" << s << " xx=(" << xx.X() << "," << xx.Y() << "," << xx.Z() << ")" 
-	    << "bool=" << (TMath::Abs(s) < kTol && ((xx.Z()-_Z1)*(xx.Z()-_Z2) <= 0.)) 
+	    << "bool=" << (TMath::Abs(s) < tol && ((xx.Z()-_Z1)*(xx.Z()-_Z2) <= 0.)) 
 	    << "_Z1=" << _Z1 << " _Z2=" << _Z2 << std::endl;
 #endif
 
-  return (TMath::Abs(s) < kTol && ((xx.Z()-_Z1)*(xx.Z()-_Z2) <= 0.));
+  return (TMath::Abs(s) < tol && ((xx.Z()-_Z1)*(xx.Z()-_Z2) <= 0.));
 } 
 
 Int_t DDConeMeasLayer::CalcXingPointWith(const TVTrack  &hel,

--- a/src/DDCylinderMeasLayer.cc
+++ b/src/DDCylinderMeasLayer.cc
@@ -58,7 +58,7 @@ DDCylinderMeasLayer::DDCylinderMeasLayer(dd4hep::rec::ISurface* surf,
     _cellIDs.push_back( encoder.lowWord() ) ;
   }
 
-  fSortingPolicy = dynamic_cast<dd4hep::rec::ICylinder*>(surf)->radius()/dd4hep::mm + side * epsilon ;
+  fSortingPolicy = dynamic_cast<dd4hep::rec::ICylinder&>(*surf).radius()/dd4hep::mm + side * epsilon ;
 
   // assumptions made here: the cylinder runs parallel to z and v ...
   

--- a/src/DDPlanarMeasLayer.cc
+++ b/src/DDPlanarMeasLayer.cc
@@ -62,7 +62,8 @@ DDPlanarMeasLayer::DDPlanarMeasLayer(dd4hep::rec::ISurface* surf, Double_t   Bz,
 
     // get global/local origin
     const dd4hep::rec::Vector3D& o = surf->origin() ;
-    const dd4hep::rec::Vector3D& oL = ((dd4hep::rec::Surface*)surf)->volSurface().origin() ;
+    dd4hep::rec::VolSurface vs = ((dd4hep::rec::Surface*)surf)->volSurface();
+    const dd4hep::rec::Vector3D& oL = vs.origin() ;
 
     // dd4hep::rec::Vector3D oR( o[0] , o[1] , 0 ) ; // radial direction of origin in global coordinates
     // if ( oR.trans2() < epsilon ){ // if origin has zero length use x-axis 


### PR DESCRIPTION
 - Fix dangling reference to potentially-deleted temporary.
 - Avoid shadowing class members with local variables.

BEGINRELEASENOTES
- Fix compilation warnings observed with current compilers.
ENDRELEASENOTES