### PR TITLE
Remove redundant dynamic_casts.

### DIFF
--- a/include/DDKalTest/DDConeMeasLayer.h
+++ b/include/DDKalTest/DDConeMeasLayer.h
@@ -98,6 +98,10 @@ public:
 
    
 private:
+  DDConeMeasLayer(dd4hep::rec::ISurface* surf,
+                  dd4hep::rec::ICone& icone,
+		  Double_t   Bz,
+		  const Char_t    *name = "DDConeMeasL") ;
 
   Double_t fsortingPolicy; // used for sorting the layers in to out
 };

--- a/include/DDKalTest/DDCylinderMeasLayer.h
+++ b/include/DDKalTest/DDCylinderMeasLayer.h
@@ -100,6 +100,9 @@ protected:
   unsigned fMDim ;
   
 private:
-  
+  DDCylinderMeasLayer(dd4hep::rec::ISurface* surf,
+                      dd4hep::rec::ICylinder& icyl,
+		      Double_t   Bz,
+		      const Char_t    *name = "DDCylinderMeasL") ;
 };
 #endif

--- a/src/DDConeMeasLayer.cc
+++ b/src/DDConeMeasLayer.cc
@@ -21,11 +21,22 @@
 DDConeMeasLayer::DDConeMeasLayer(dd4hep::rec::ISurface* surf,
 				 Double_t   Bz,
 				 const Char_t  *name ) :
+  DDConeMeasLayer (surf,
+                   dynamic_cast<dd4hep::rec::ICone&>(*surf),
+                   Bz,
+                   name)
+{
+}
+
+DDConeMeasLayer::DDConeMeasLayer(dd4hep::rec::ISurface* surf,
+                                 dd4hep::rec::ICone& icone,
+				 Double_t   Bz,
+				 const Char_t  *name ) :
   DDVMeasLayer(  surf, Bz, name ) ,
-  Data(dynamic_cast<dd4hep::rec::ICone*>(surf)->z0()/dd4hep::mm ,
-       dynamic_cast<dd4hep::rec::ICone*>(surf)->radius0()/dd4hep::mm,
-       dynamic_cast<dd4hep::rec::ICone*>(surf)->z1()/dd4hep::mm,
-       dynamic_cast<dd4hep::rec::ICone*>(surf)->radius1()/dd4hep::mm ),
+  Data(icone.z0()/dd4hep::mm ,
+       icone.radius0()/dd4hep::mm,
+       icone.z1()/dd4hep::mm,
+       icone.radius1()/dd4hep::mm ),
   TCutCone(_R1*(_Z2-_Z1)/(_R2-_R1), 
    	   _R2*(_Z2-_Z1)/(_R2-_R1), 
    	   (_R2-_R1)/(_Z2-_Z1),

--- a/src/DDCylinderMeasLayer.cc
+++ b/src/DDCylinderMeasLayer.cc
@@ -33,13 +33,25 @@ using namespace UTIL ;
 DDCylinderMeasLayer::DDCylinderMeasLayer(dd4hep::rec::ISurface* surf,
 					 Double_t   Bz,
 					 const Char_t  *name ) :
+  DDCylinderMeasLayer (surf,
+                       dynamic_cast<dd4hep::rec::ICylinder&>(*surf),
+                       Bz,
+                       name)
+{
+}
+
+
+DDCylinderMeasLayer::DDCylinderMeasLayer(dd4hep::rec::ISurface* surf,
+                                         dd4hep::rec::ICylinder& icyl,
+					 Double_t   Bz,
+					 const Char_t  *name ) :
   DDVMeasLayer(  surf, Bz, name ) ,
   
-  TCylinder(  dynamic_cast<dd4hep::rec::ICylinder*>(surf)->radius()/dd4hep::mm ,
+  TCylinder(  icyl.radius()/dd4hep::mm ,
 	      surf->length_along_v()/dd4hep::mm / 2. , 
-	      dynamic_cast<dd4hep::rec::ICylinder*>(surf)->center().x()/dd4hep::mm,
-	      dynamic_cast<dd4hep::rec::ICylinder*>(surf)->center().y()/dd4hep::mm ,
-	      dynamic_cast<dd4hep::rec::ICylinder*>(surf)->center().z()/dd4hep::mm ),
+	      icyl.center().x()/dd4hep::mm,
+	      icyl.center().y()/dd4hep::mm ,
+	      icyl.center().z()/dd4hep::mm ),
   
   fSortingPolicy(0.),
   


### PR DESCRIPTION
Also get an exception if the cast fails, rather than a null pointer dereference.

BEGINRELEASENOTES
- Remove redundant uses of dynamic_cast.
ENDRELEASENOTES